### PR TITLE
Update TensorFlow/Keras legacy APIs, test Python 3.12

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,7 +32,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          # - "3.12"
+          - "3.12"
 
     steps:
     - name: Configure hostname

--- a/pyspod/emulation/neural_nets.py
+++ b/pyspod/emulation/neural_nets.py
@@ -22,14 +22,9 @@ from pyspod.emulation.base import Base
 
 # set seeds
 from numpy.random import seed; seed(1)
-tf.compat.v1.set_random_seed(2)
-
-# start session
-session_conf = tf.compat.v1.ConfigProto(
-    intra_op_parallelism_threads=1, inter_op_parallelism_threads=1)
-session = tf.compat.v1.Session(
-    graph=tf.compat.v1.get_default_graph(), config=session_conf)
-tf.compat.v1.keras.backend.set_session(session)
+tf.random.set_seed(2)
+tf.config.threading.set_intra_op_parallelism_threads(1)
+tf.config.threading.set_inter_op_parallelism_threads(1)
 
 
 
@@ -173,7 +168,7 @@ class Neural_Nets(Base):
         ## compute real part
         cnt = 0
         name_tmp = 'real'+str(idx)
-        name_real = os.path.join(self._savedir, name_tmp+'__weights.h5')
+        name_real = os.path.join(self._savedir, name_tmp+'.weights.h5')
         self.model.load_weights(name_real)
         for t in tqdm(range(n_seq_in,nt,n_seq_out), desc='inference_real'):
             idx_x[cnt,...] = np.arange(t-n_seq_in, t)
@@ -188,7 +183,7 @@ class Neural_Nets(Base):
         if not np.isreal(data_in).all():
             cnt = 0
             name_tmp = 'imag'+str(idx)
-            name_imag = os.path.join(self._savedir, name_tmp+'__weights.h5')
+            name_imag = os.path.join(self._savedir, name_tmp+'.weights.h5')
             self.model.load_weights(name_imag)
             for t in tqdm(range(n_seq_in,nt,n_seq_out), desc='inference_imag'):
                 idx_x[cnt,...] = np.arange(t-n_seq_in, t)
@@ -213,7 +208,7 @@ class Neural_Nets(Base):
         valid_data_ip, valid_data_op = self.extract_sequences(data=data_valid)
 
         # training
-        name_filepath = os.path.join(self._savedir, name+'__weights.h5')
+        name_filepath = os.path.join(self._savedir, name+'.weights.h5')
         cb_chk = tf.keras.callbacks.ModelCheckpoint(
             name_filepath,
             monitor='loss',

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ version = attr: pyspod.__version__
 description = Python Spectral Proper Orthogonal Decomposition
 long_description = file:README.md
 long_description_content_type = text/markdown
-author = Gianmarco Mengaldo, Marcin Rogoswki, Lisandro Dalcin, Romit Maulik, Andrea Lario
+author = Gianmarco Mengaldo, Marcin Rogowski, Lisandro Dalcin, Romit Maulik, Andrea Lario
 author_email = mpegim@nus.edu.sg, marcin.rogowski@gmail.com, dalcinl@gmail.com, rmaulik@anl.gov, alario@sissa.it
 url = https://github.com/MathEXLab/PySPOD
 license = MIT
@@ -16,11 +16,11 @@ classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering :: Mathematics
 
 [options]


### PR DESCRIPTION
- TensorFlow 2.16.1 uses Keras 3.0 as the default. It seems that the `set_session` function which was used in PySPOD does not exist anymore.
- Fixes: ```ValueError: When using `save_weights_only=True` in `ModelCheckpoint`, the filepath provided must end in `.weights.h5` (Keras weights format).` Received: filepath=[...]/real0__weights.h5```
- We were previously not testing Python 3.12 because there was no TensorFlow for Python 3.12 on PyPI. They have since added it.