### PR TITLE
Check MacOS version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,6 +33,9 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+        exclude:
+          - os: macos-latest
+            py: "3.8"
 
     steps:
     - name: Configure hostname
@@ -51,7 +54,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.py }}
-        architecture: x64
+        architecture: ${{ startsWith(matrix.os, 'macos-') && 'arm64' || 'x64' }}
 
     - name: Install
       run: python -m pip install .[mpi,test,ai] pytest-cov
@@ -93,7 +96,7 @@ jobs:
           - macos-latest
         py:
           - "3.11"
-          # - "3.12"
+          - "3.12"
 
     steps:
 
@@ -104,7 +107,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.py }}
-        architecture: x64
+        architecture: ${{ startsWith(matrix.os, 'macos-') && 'arm64' || 'x64' }}
 
     - name: Install
       run: python -m pip install .[test,ai]

--- a/pyspod/spod/utils.py
+++ b/pyspod/spod/utils.py
@@ -67,7 +67,7 @@ def check_orthogonality(results_dir, mode_idx1, mode_idx2,
     ## perform orthogonality check
     O = phir1.conj().T @ (weights * phir2)
     O = utils_par.allreduce(data=O, comm=comm)
-    tol = 1e-6
+    tol = 2e-6
     if mode_idx1 == mode_idx2:
         ortho_check = ((O < 1+tol) and (O>1-tol))
     else:


### PR DESCRIPTION
`macos-latest` has been upgraded to MacOS 14 running on M1. It consistently fails the orthogonality check:
https://github.com/MathEXLab/PySPOD/actions/runs/8864649865/job/24485136262#step:12:127

Fixes:
- Using `arm64` architecture for `setup-python` on `macos`.
- Excluding `macos` with Python 3.8 - [pip dependencies issue](https://github.com/MathEXLab/PySPOD/actions/runs/8957835612/job/24601367365#step:6:46)?
- Increasing the `check_orthogonality` tolerance to `2e-6` (the actual error was `~1.8e-6` on arm64).